### PR TITLE
added start_date to challenges as new column

### DIFF
--- a/db/migrate/20230606130652_fix_column_name.rb
+++ b/db/migrate/20230606130652_fix_column_name.rb
@@ -1,5 +1,0 @@
-class FixColumnName < ActiveRecord::Migration[7.0]
-  def change
-    rename_column :challenges, :created_date, :start_date
-  end
-end

--- a/db/migrate/20230607122741_add_start_date_to_challenges.rb
+++ b/db/migrate/20230607122741_add_start_date_to_challenges.rb
@@ -1,0 +1,5 @@
+class AddStartDateToChallenges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :challenges, :start_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_095744) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_07_122741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,10 +23,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_095744) do
   create_table "challenges", force: :cascade do |t|
     t.bigint "keyword_id", null: false
     t.bigint "user_id", null: false
-    t.date "start_date"
-    t.bigint "post_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "start_date"
     t.index ["keyword_id"], name: "index_challenges_on_keyword_id"
     t.index ["user_id"], name: "index_challenges_on_user_id"
   end


### PR DESCRIPTION
deleted start_date migration that was replacing created_date column, because I deleted the created_date before
created a new column start_date as a new migration instead to resolve conflicts